### PR TITLE
colocation時のMisskey投稿を良い感じに

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -260,13 +260,20 @@ async fn run_checks_once(
                         let now = Utc::now();
                         if now - prev_state.last_notification_timestamp > ChronoDuration::minutes(5)
                         {
+                            let domain = result.url
+                                .parse::<url::Url>()
+                                .map(|u| u.host_str().unwrap_or(&result.url).to_string())
+                                .unwrap_or(result.url.clone());
+                            let rtt_color = match result.rtt_millis {
+                                Some(0..=299) => "3a3",   // green
+                                Some(300..=499) => "991", // yellow
+                                Some(500..=999) => "c52", // orange
+                                Some(_) => "b22",         // red
+                                None => "999",            // gray for no data
+                            };
                             let message = format!(
-                                "Cloudflare colocation for ?[{}]({}) changed: `{}` -> `{}` (RTT: {}ms)",
-                                result.url,
-                                result.url,
-                                prev_colo,
-                                curr_colo,
-                                result.rtt_millis.unwrap_or(0)
+                                "?[{}]({}) <small>`{}`</small>→`{}` $[border.color=0000,radius=10 $[bg.color={} $[fg.color=fff  {}<small>ms</small> ]]]",
+                                domain, result.url, prev_colo, curr_colo, rtt_color, result.rtt_millis.unwrap_or(0)
                             );
                             colo_change_messages.push(message);
                             prev_state.last_notification_timestamp = now;


### PR DESCRIPTION
# what
colocation時の投稿の表記を見やすく
<img width="565" height="291" alt="image" src="https://github.com/user-attachments/assets/132f3982-9178-4ac8-8d60-27512814a814" />

# why
なんとなく

# Checklist
- [x] ビルド確認済

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 通知メッセージを刷新し、URLから抽出したドメインを表示。
  - 旧/新の接続拠点（colo）を明示して比較しやすく改善。
  - RTTを範囲別に色分け表示し、状態を直感的に把握可能に。
  - 通知の時間制御（スロットリング）は従来どおり維持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->